### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Identicon
+# Identicon
 
 Identicon is github's [Identicons](https://github.com/blog/1586-identicons) clone in Go
 
-##Simple example
+## Simple example
 
 Type: Horizontal, Theme: White (Default)
 ```go


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
